### PR TITLE
Task 7

### DIFF
--- a/authorization-service/.gitignore
+++ b/authorization-service/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+jspm_packages
+
+.serverless
+
+.webpack
+
+.env

--- a/authorization-service/.npmignore
+++ b/authorization-service/.npmignore
@@ -1,0 +1,9 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless
+
+# Webpack directories
+.webpack

--- a/authorization-service/.nvmrc
+++ b/authorization-service/.nvmrc
@@ -1,0 +1,1 @@
+lts/fermium

--- a/authorization-service/README.md
+++ b/authorization-service/README.md
@@ -1,0 +1,95 @@
+# Serverless - AWS Node.js Typescript
+
+This project has been generated using the `aws-nodejs-typescript` template from the [Serverless framework](https://www.serverless.com/).
+
+For detailed instructions, please refer to the [documentation](https://www.serverless.com/framework/docs/providers/aws/).
+
+## Installation/deployment instructions
+
+Depending on your preferred package manager, follow the instructions below to deploy your project.
+
+> **Requirements**: NodeJS `lts/fermium (v.14.15.0)`. If you're using [nvm](https://github.com/nvm-sh/nvm), run `nvm use` to ensure you're using the same Node version in local and in your lambda's runtime.
+
+### Using NPM
+
+- Run `npm i` to install the project dependencies
+- Run `npx sls deploy` to deploy this stack to AWS
+
+### Using Yarn
+
+- Run `yarn` to install the project dependencies
+- Run `yarn sls deploy` to deploy this stack to AWS
+
+## Test your service
+
+This template contains a single lambda function triggered by an HTTP request made on the provisioned API Gateway REST API `/hello` route with `POST` method. The request body must be provided as `application/json`. The body structure is tested by API Gateway against `src/functions/hello/schema.ts` JSON-Schema definition: it must contain the `name` property.
+
+- requesting any other path than `/hello` with any other method than `POST` will result in API Gateway returning a `403` HTTP error code
+- sending a `POST` request to `/hello` with a payload **not** containing a string property named `name` will result in API Gateway returning a `400` HTTP error code
+- sending a `POST` request to `/hello` with a payload containing a string property named `name` will result in API Gateway returning a `200` HTTP status code with a message saluting the provided name and the detailed event processed by the lambda
+
+> :warning: As is, this template, once deployed, opens a **public** endpoint within your AWS account resources. Anybody with the URL can actively execute the API Gateway endpoint and the corresponding lambda. You should protect this endpoint with the authentication method of your choice.
+
+### Locally
+
+In order to test the hello function locally, run the following command:
+
+- `npx sls invoke local -f hello --path src/functions/hello/mock.json` if you're using NPM
+- `yarn sls invoke local -f hello --path src/functions/hello/mock.json` if you're using Yarn
+
+Check the [sls invoke local command documentation](https://www.serverless.com/framework/docs/providers/aws/cli-reference/invoke-local/) for more information.
+
+### Remotely
+
+Copy and replace your `url` - found in Serverless `deploy` command output - and `name` parameter in the following `curl` command in your terminal or in Postman to test your newly deployed application.
+
+```
+curl --location --request POST 'https://myApiEndpoint/dev/hello' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "name": "Frederic"
+}'
+```
+
+## Template features
+
+### Project structure
+
+The project code base is mainly located within the `src` folder. This folder is divided in:
+
+- `functions` - containing code base and configuration for your lambda functions
+- `libs` - containing shared code base between your lambdas
+
+```
+.
+├── src
+│   ├── functions               # Lambda configuration and source code folder
+│   │   ├── hello
+│   │   │   ├── handler.ts      # `Hello` lambda source code
+│   │   │   ├── index.ts        # `Hello` lambda Serverless configuration
+│   │   │   ├── mock.json       # `Hello` lambda input parameter, if any, for local invocation
+│   │   │   └── schema.ts       # `Hello` lambda input event JSON-Schema
+│   │   │
+│   │   └── index.ts            # Import/export of all lambda configurations
+│   │
+│   └── libs                    # Lambda shared code
+│       └── apiGateway.ts       # API Gateway specific helpers
+│       └── handlerResolver.ts  # Sharable library for resolving lambda handlers
+│       └── lambda.ts           # Lambda middleware
+│
+├── package.json
+├── serverless.ts               # Serverless service file
+├── tsconfig.json               # Typescript compiler configuration
+├── tsconfig.paths.json         # Typescript paths
+└── webpack.config.js           # Webpack configuration
+```
+
+### 3rd party libraries
+
+- [json-schema-to-ts](https://github.com/ThomasAribart/json-schema-to-ts) - uses JSON-Schema definitions used by API Gateway for HTTP request validation to statically generate TypeScript types in your lambda's handler code base
+- [middy](https://github.com/middyjs/middy) - middleware engine for Node.Js lambda. This template uses [http-json-body-parser](https://github.com/middyjs/middy/tree/master/packages/http-json-body-parser) to convert API Gateway `event.body` property, originally passed as a stringified JSON, to its corresponding parsed object
+- [@serverless/typescript](https://github.com/serverless/typescript) - provides up-to-date TypeScript definitions for your `serverless.ts` service file
+
+### Advanced usage
+
+Any tsconfig.json can be used, but if you do, set the environment variable `TS_NODE_CONFIG` for building the application, eg `TS_NODE_CONFIG=./tsconfig.app.json npx serverless webpack`

--- a/authorization-service/package.json
+++ b/authorization-service/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "authorization-service",
+  "version": "1.0.0",
+  "description": "Serverless aws-nodejs-typescript template",
+  "main": "serverless.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "engines": {
+    "node": ">=14.15.0"
+  },
+  "dependencies": {
+    "@middy/core": "^1.5.2",
+    "@middy/http-json-body-parser": "^1.5.2",
+    "source-map-support": "^0.5.19"
+  },
+  "devDependencies": {
+    "@serverless/typescript": "^2.23.0",
+    "@types/aws-lambda": "^8.10.71",
+    "@types/node": "^14.14.25",
+    "json-schema-to-ts": "^1.5.0",
+    "serverless": "^2.23.0",
+    "serverless-dotenv-plugin": "^3.10.0",
+    "serverless-webpack": "^5.3.5",
+    "ts-loader": "^8.0.15",
+    "ts-node": "^9.1.1",
+    "tsconfig-paths": "^3.9.0",
+    "tsconfig-paths-webpack-plugin": "^3.3.0",
+    "typescript": "^4.1.3",
+    "webpack": "^5.20.2",
+    "webpack-node-externals": "^2.5.2"
+  },
+  "author": "The serverless webpack authors (https://github.com/elastic-coders/serverless-webpack)",
+  "license": "MIT"
+}

--- a/authorization-service/serverless.ts
+++ b/authorization-service/serverless.ts
@@ -1,0 +1,44 @@
+import type { AWS } from '@serverless/typescript';
+
+import basicAuthorizer from '@functions/basicAuthorizer';
+
+const serverlessConfiguration: AWS = {
+  service: 'authorization-service',
+  frameworkVersion: '2',
+  useDotenv: true,
+  custom: {
+    webpack: {
+      webpackConfig: './webpack.config.js',
+      includeModules: true,
+    },
+  },
+  plugins: ['serverless-webpack', 'serverless-dotenv-plugin'],
+  provider: {
+    name: 'aws',
+    runtime: 'nodejs14.x',
+    region: 'eu-west-1',
+    apiGateway: {
+      minimumCompressionSize: 1024,
+      shouldStartNameWithService: true,
+    },
+    environment: {
+      AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
+    },
+    lambdaHashingVersion: '20201221',
+  },
+  functions: { basicAuthorizer },
+  resources: {
+    Outputs: {
+      basicAuthorizerArn: {
+        Value: {
+          'Fn::GetAtt': ['BasicAuthorizerLambdaFunction', 'Arn'],
+        },
+        Export: {
+          Name: '\${self:service}-\${self:provider.stage}-BasicAuthorizerArn',
+        },
+      },
+    },
+  },
+};
+
+module.exports = serverlessConfiguration;

--- a/authorization-service/src/functions/basicAuthorizer/handler.ts
+++ b/authorization-service/src/functions/basicAuthorizer/handler.ts
@@ -1,0 +1,46 @@
+import 'source-map-support/register';
+
+import { APIGatewayAuthorizerResult, APIGatewayTokenAuthorizerHandler } from 'aws-lambda';
+
+import { middyfy } from '@libs/lambda';
+
+export const generatePolicy = (principalId, Resource, Effect): APIGatewayAuthorizerResult => {
+  return {
+    principalId,
+    policyDocument: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Action: 'execute-api:Invoke',
+          Effect,
+          Resource
+        },
+      ],
+    },
+  };
+};
+
+export const basicAuthorizer: APIGatewayTokenAuthorizerHandler = (event, _ctx, cb) => {
+  console.log(`[basicAuthorizer] Event: ${JSON.stringify(event)}`);
+
+  if (event.type !== 'TOKEN') {
+    cb('Unauthorized');
+  }
+
+  try {
+    const { authorizationToken } = event;
+    const encodedCreds = authorizationToken.split(' ')[1];
+    const [username, password] = Buffer.from(encodedCreds, 'base64')
+      .toString('utf-8')
+      .split(':');
+
+    const storedUserPassword = process.env[username.toLowerCase()];
+    const effect = !storedUserPassword || storedUserPassword !== password ? 'Deny' : 'Allow';
+
+    cb(null, generatePolicy(encodedCreds, event.methodArn, effect));
+  } catch (error) {
+    cb(`Unauthorized: ${error.message}`);
+  }
+};
+
+export const main = middyfy(basicAuthorizer);

--- a/authorization-service/src/functions/basicAuthorizer/index.ts
+++ b/authorization-service/src/functions/basicAuthorizer/index.ts
@@ -1,0 +1,5 @@
+import { handlerPath } from '@libs/handlerResolver';
+
+export default {
+  handler: `${handlerPath(__dirname)}/handler.main`,
+}

--- a/authorization-service/src/functions/index.ts
+++ b/authorization-service/src/functions/index.ts
@@ -1,0 +1,1 @@
+export { default as basicAuthorizer } from './basicAuthorizer';

--- a/authorization-service/src/libs/handlerResolver.ts
+++ b/authorization-service/src/libs/handlerResolver.ts
@@ -1,0 +1,3 @@
+export const handlerPath = (context: string): string => {
+  return `${context.split(process.cwd())[1].substring(1).replace(/\\/g, '/')}`
+};

--- a/authorization-service/src/libs/lambda.ts
+++ b/authorization-service/src/libs/lambda.ts
@@ -1,0 +1,6 @@
+import middy from "@middy/core"
+import middyJsonBodyParser from "@middy/http-json-body-parser"
+
+export const middyfy = (handler) => {
+  return middy(handler).use(middyJsonBodyParser())
+}

--- a/authorization-service/tsconfig.json
+++ b/authorization-service/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "./tsconfig.paths.json",
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "removeComments": true,
+    "sourceMap": true,
+    "target": "ES2020",
+    "outDir": "lib"
+  },
+  "include": ["src/**/*.ts", "serverless.ts"],
+  "exclude": [
+    "node_modules/**/*",
+    ".serverless/**/*",
+    ".webpack/**/*",
+    "_warmup/**/*",
+    ".vscode/**/*"
+  ],
+  "ts-node": {
+    "require": ["tsconfig-paths/register"]
+  }
+}

--- a/authorization-service/tsconfig.paths.json
+++ b/authorization-service/tsconfig.paths.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@functions/*": ["src/functions/*"],
+      "@libs/*": ["src/libs/*"]
+    }
+  }
+}

--- a/authorization-service/webpack.config.js
+++ b/authorization-service/webpack.config.js
@@ -1,0 +1,57 @@
+const path = require('path');
+const slsw = require('serverless-webpack');
+const nodeExternals = require('webpack-node-externals');
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+
+/*
+This line is only required if you are specifying `TS_NODE_PROJECT` for whatever reason.
+ */
+// delete process.env.TS_NODE_PROJECT;
+
+module.exports = {
+  context: __dirname,
+  mode: slsw.lib.webpack.isLocal ? 'development' : 'production',
+  entry: slsw.lib.entries,
+  devtool: slsw.lib.webpack.isLocal ? 'eval-cheap-module-source-map' : 'source-map',
+  resolve: {
+    extensions: ['.mjs', '.json', '.ts'],
+    symlinks: false,
+    cacheWithContext: false,
+    plugins: [
+      new TsconfigPathsPlugin({
+        configFile: './tsconfig.paths.json',
+      }),
+    ],
+  },
+  output: {
+    libraryTarget: 'commonjs',
+    path: path.join(__dirname, '.webpack'),
+    filename: '[name].js',
+  },
+  optimization: {
+    concatenateModules: false,
+  },
+  target: 'node',
+  externals: [nodeExternals()],
+  module: {
+    rules: [
+      // all files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
+      {
+        test: /\.(tsx?)$/,
+        loader: 'ts-loader',
+        exclude: [
+          [
+            path.resolve(__dirname, 'node_modules'),
+            path.resolve(__dirname, '.serverless'),
+            path.resolve(__dirname, '.webpack'),
+          ],
+        ],
+        options: {
+          transpileOnly: true,
+          experimentalWatchApi: true,
+        },
+      },
+    ],
+  },
+  plugins: [],
+};

--- a/import-service/serverless.ts
+++ b/import-service/serverless.ts
@@ -47,6 +47,36 @@ const serverlessConfiguration: AWS = {
     ]
   },
   functions: { importProductsFile, importFileParser },
+  resources: {
+    Resources: {
+      GatewayResponseDefault4XX: {
+        Type: 'AWS::ApiGateway::GatewayResponse',
+        Properties: {
+          ResponseParameters: {
+            'gatewayresponse.header.Access-Control-Allow-Origin': "'*'",
+            'gatewayresponse.header.Access-Control-Allow-Headers': "'*'",
+          },
+          ResponseType: 'DEFAULT_4XX',
+          RestApiId: {
+            Ref: 'ApiGatewayRestApi',
+          },
+        },
+      },
+      GatewayResponseDefault5XX: {
+        Type: 'AWS::ApiGateway::GatewayResponse',
+        Properties: {
+          ResponseParameters: {
+            'gatewayresponse.header.Access-Control-Allow-Origin': "'*'",
+            'gatewayresponse.header.Access-Control-Allow-Headers': "'*'",
+          },
+          ResponseType: 'DEFAULT_5XX',
+          RestApiId: {
+            Ref: 'ApiGatewayRestApi',
+          },
+        },
+      },
+    },
+  },
 };
 
 module.exports = serverlessConfiguration;

--- a/import-service/src/functions/importProductsFile/index.ts
+++ b/import-service/src/functions/importProductsFile/index.ts
@@ -7,12 +7,22 @@ export default {
       http: {
         method: 'get',
         path: 'import',
+        cors: true,
         request: {
           parameters: {
             querystrings: {
               name: true
             }
           }
+        },
+        authorizer: {
+          name: 'basicAuthorizer',
+          arn: {
+            'Fn::ImportValue': `authorization-service-\${self:provider.stage}-BasicAuthorizerArn`,
+          },
+          resultTtlInSeconds: 0,
+          identitySource: 'method.request.header.Authorization',
+          type: 'token',
         }
       }
     }


### PR DESCRIPTION
# Task 7
https://github.com/rolling-scopes-school/nodejs-aws-tasks/blob/main/task7-lambda%2Bcognito-authorization/task.md

_Completed: 17 Oct 2021_

## Links
- [app (frontend)](https://dd1vsnw9zieqf.cloudfront.net)
- [frontend PR](https://github.com/zheromskyV/shop-angular-cloudfront/pull/4)

## Scope

### Main

- [x] 1 - authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
- [x] 3 - import-service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
- [x] 5 - update client application to send Authorization: Basic authorization_token header on import. Client should get authorization_token value from browser localStorage https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage authorization_token = localStorage.getItem('authorization_token')

### Additional
- [x] +1 Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file

#### Total: 5 + 1 = 6

